### PR TITLE
README: link a View-system alternative for non-Compose projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A customizable Liquid Glass effect library for Compose Multiplatform.
 
+> Working with the classic Android View system (XML layouts) rather than Compose? See [Liquid-Glass-Android](https://github.com/QWEA0/Liquid-Glass-Android), a `FrameLayout` implementation with an API 24 floor.
+
 ## Docs
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.kyant0/backdrop)](https://central.sonatype.com/artifact/io.github.kyant0/backdrop)


### PR DESCRIPTION
Adds a one-line pointer under the description for people who land here with a View-system (XML) project.

Liquid-Glass-Android is a `FrameLayout` implementation for the classic View hierarchy with an API 24 floor; its README already directs Compose users to this library, so this just closes the loop in the other direction. Happy to reword or drop it if you'd rather not link out.
